### PR TITLE
Add DFP packs from https://github.com/Infineon/cmsis-packs

### DIFF
--- a/Infineon.pidx
+++ b/Infineon.pidx
@@ -2,7 +2,7 @@
 <index schemaVersion="1.1.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
   <vendor>Infineon</vendor>
   <url>https://github.com/Infineon/cmsis_packs/raw/master/</url>
-  <timestamp>2024-09-24T10:01:00.5676577+00:00</timestamp>
+  <timestamp>2024-11-06T14:48:00.5676577+00:00</timestamp>
   <pindex>
     <pdsc url="https://www.infineon.com/cmsis_packs/XMC1000/" vendor="Infineon" name="XMC1000_DFP" version="2.12.0" />
     <pdsc url="https://www.infineon.com/cmsis_packs/XMC4000/" vendor="Infineon" name="XMC4000_DFP" version="2.14.0" />
@@ -17,5 +17,9 @@
     <pdsc url="https://itools.infineon.com/cmsis_packs/T2G-B-E/" vendor="Infineon" name="T2G-B-E_DFP" version="1.0.0" />
     <pdsc url="https://itools.infineon.com/cmsis_packs/KIT_T2G-B-H_LITE_BSP/" vendor="Infineon" name="KIT_T2G-B-H_LITE_BSP" version="1.0.0" />
     <pdsc url="https://itools.infineon.com/cmsis_packs/KIT_T2G-B-E_LITE_BSP/" vendor="Infineon" name="KIT_T2G-B-E_LITE_BSP" version="1.0.0" />
+    <pdsc url="https://itools.infineon.com/cmsis_packs/AIROC_DFP/" vendor="Infineon" name="AIROC_DFP" version="1.2.0"/>
+    <pdsc url="https://itools.infineon.com/cmsis_packs/CAT1C_DFP/" vendor="Infineon" name="CAT1C_DFP" version="1.0.0"/>
+    <pdsc url="https://itools.infineon.com/cmsis_packs/CAT2_DFP/" vendor="Infineon" name="CAT2_DFP" version="1.3.0"/>
+    <pdsc url="https://itools.infineon.com/cmsis_packs/CAT1A_DFP/" vendor="Infineon" name="CAT1A_DFP" version="1.5.0"/>
   </pindex>
 </index>


### PR DESCRIPTION
Update Infineon.pidx to add active CMSIS DFP packs previously listed at https://github.com/Infineon/cmsis-packs/blob/master/Cypress.pidx:

* Infineon.AIROC_DFP
* Infineon.CAT1C_DFP
* Infineon.CAT2_DFP
* Infineon.CAT1A_DFP

Update PDSC files to use https://itools.infineon.com/cmsis_packs/ as base URL instead of https://github.com/Infineon/cmsis-packs

See also: https://github.com/Infineon/cmsis-packs/pull/3