### PR TITLE
relocate XMC1000/XMC4000

### DIFF
--- a/Infineon.pidx
+++ b/Infineon.pidx
@@ -4,8 +4,8 @@
   <url>https://github.com/Infineon/cmsis_packs/raw/master/</url>
   <timestamp>2024-11-06T14:48:00.5676577+00:00</timestamp>
   <pindex>
-    <pdsc url="https://www.infineon.com/cmsis_packs/XMC1000/" vendor="Infineon" name="XMC1000_DFP" version="2.12.0" />
-    <pdsc url="https://www.infineon.com/cmsis_packs/XMC4000/" vendor="Infineon" name="XMC4000_DFP" version="2.14.0" />
+    <pdsc url="https://itools.infineon.com/cmsis_packs/XMC1000/" vendor="Infineon" name="XMC1000_DFP" version="2.12.0" />
+    <pdsc url="https://itools.infineon.com/cmsis_packs/XMC4000/" vendor="Infineon" name="XMC4000_DFP" version="2.14.0" />
     <pdsc url="https://itools.infineon.com/cmsis_packs/TLE984x/" vendor="Infineon" name="TLE984x_DFP" version="1.3.4" />
     <pdsc url="https://itools.infineon.com/cmsis_packs/TLE985x/" vendor="Infineon" name="TLE985x_DFP" version="1.2.0" />
     <pdsc url="https://itools.infineon.com/cmsis_packs/TLE986x/" vendor="Infineon" name="TLE986x_DFP" version="1.4.6" />


### PR DESCRIPTION
https://itools.infineon.com/cmsis_packs/
already has updated pdsc and pack versions for XMC1000 and XMC4000.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
The aim of this PR is consistency in the hosting of the Open-CMSIS-Packs from Infineon.
For XMC1000 and XMC4000 the url has not yet been updated.
All packs from Infineon should be located here: https://itools.infineon.com/cmsis_packs/

Context
I am working for Arm and we are maintaining the public index file of all Open-CMSIS-Packs hosted by partners.
https://www.keil.com/pack/index.pidx
We have registered the package index file from Infineon: https://github.com/Infineon/cmsis_packs/raw/master/Infineon.pidx
in the vendor index file: https://www.keil.com/pack/Keil.vidx

